### PR TITLE
Bounded searching for accuracy

### DIFF
--- a/conf/resources/requirejsBootstrap.js
+++ b/conf/resources/requirejsBootstrap.js
@@ -48,12 +48,26 @@ var require;
     // itself.
     function webjarLoader(name, req, onload, config) {
         var route, routeKey;
-        routeKey = getReverseFullPath(name);
+
+        function prependSlash(n) {
+            return (n.substring(0, 1) === "/" ? n : "/" + n);
+        }
+
+        function appendJs(n) {
+            var dotPosn = n.lastIndexOf(".");
+            if (dotPosn > -1 && dotPosn > n.lastIndexOf("/")) {
+                return n;
+            }
+            return n + ".js";
+        }
+
+        routeKey = getReverseFullPath(appendJs(prependSlash(name)));
         route = routes[routeKey];
         if (route === undefined) {
             throw "No WebJar dependency found for " + name +
                 ". Please ensure that this is a valid dependency";
         }
+
         function mainLoader() {
             req([route.fullPath], onload);
         }
@@ -89,7 +103,9 @@ var require;
 
     origCallback = require.callback;
     require.callback = function () {
-        if (origCallback !== undefined) origCallback();
+        if (origCallback !== undefined) {
+            origCallback();
+        }
         define("webjars", function () {
             return {load: webjarLoader};
         });


### PR DESCRIPTION
Enhanced reliable searching by bounding the resource with a path separator and appending an extension of ".js" if one cannot be found. This avoids situations where "webjars!text" may resolve to "textile.js".
