### PR TITLE
update webjars-locator due to NPE

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ resolvers += "Local Maven" at Path.userHome.asFile.toURI.toURL + ".m2/repository
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play" % "2.3.0" % "provided",
   "org.webjars" % "requirejs" % "2.1.10",
-  "org.webjars" % "webjars-locator" % "0.14",
+  "org.webjars" % "webjars-locator" % "0.18",
   "org.specs2" %% "specs2" % "2.3.11" % "test",
   "com.typesafe.play" %% "play-test" % "2.3.0" % "test",
   "org.webjars" % "bootstrap" % "3.1.0" % "test",


### PR DESCRIPTION
All instructions in the guide and in the Webjars documentation leads to NPE:

e.g.

```
[NullPointerException: null]
5        var require = {
6            callback: function() {
7            // default requirejs configs
8                @for(webJarJson <- org.webjars.RequireJS.getSetupJson(routes.WebJarAssets.at("").url).values()) {
```

It's probably related to

https://github.com/webjars/webjars-locator/issues/60
