### PR TITLE
refactor WebJarsUtil

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,3 +61,5 @@ developers := List(
 )
 
 useGpg := true
+
+enablePlugins(SbtTwirl)

--- a/src/main/scala/org/webjars/play/WebJarsUtil.scala
+++ b/src/main/scala/org/webjars/play/WebJarsUtil.scala
@@ -5,6 +5,7 @@ import javax.inject.{Inject, Singleton}
 import org.webjars.WebJarAssetLocator
 import play.api.mvc.Call
 import play.api.{Configuration, Environment, Logger, Mode}
+import play.twirl.api.{Html, HtmlFormat}
 
 import scala.util.{Failure, Success, Try}
 import scala.util.matching.Regex
@@ -29,23 +30,95 @@ class WebJarsUtil @Inject() (configuration: Configuration, environment: Environm
   lazy val cdnUrl: String = configuration.getOptional[String]("webjars.cdn-url").getOrElse("https://cdn.jsdelivr.net/webjars")
   lazy val useCdn: Boolean = configuration.getOptional[Boolean]("webjars.use-cdn").getOrElse(false)
 
+  class WebJarAsset(val path: Try[String]) {
+    /**
+      * Get the groupId from a path
+      *
+      * @example groupId("jquery/1.9.0/jquery.js") will return "org.webjars" if the classpath contains the org.webjars jquery jar
+      *
+      * @param path a string to parse a WebJar name from
+      * @return the artifact groupId based on the classpath
+      */
+    def groupId(path: String): Try[String] = {
+      val webJar = path.split("/").head
+      val suffix = s"/$webJar/pom.xml"
+      val prefix = "META-INF/maven/"
+      val fullPathTry = Try(webJarAssetLocator.getFullPath(suffix))
+
+      fullPathTry.map(_.stripSuffix(suffix).stripPrefix(prefix))
+    }
+
+    private[this] def tag(f: String => Html): Html =
+      url.fold(err => {
+          val errMsg = s"couldn't find asset $path"
+          Logger.error(errMsg, err)
+          environment.mode match {
+            case Mode.Prod =>
+              Html("")
+            case _ =>
+              throw err
+          }
+      }, f)
+
+    def script(params: Map[String, String] = Map.empty): Html =
+      tag(html.script(_, params))
+
+    /**
+      * A CSS link tag
+      *
+      * @return An Html with the tag or an error / empty string (depending on mode)
+      */
+    def css(params: Map[String, String] = Map.empty): Html =
+      tag(html.css(_, params))
+
+    /**
+      * A img tag
+      *
+      * @return An Html with the tag or an error / empty string (depending on mode)
+      */
+
+    def img(params: Map[String, String] = Map.empty): Html =
+      tag(html.img(_, params))
+
+    /**
+      * Get the asset's reverse route
+      */
+    def url: Try[String] =
+      path.flatMap { p =>
+        if (useCdn) {
+          val groupIdTry = groupId(p)
+          groupIdTry.map { groupId =>
+            s"$cdnUrl/$groupId/$p"
+          }
+        }
+        else {
+          Success(routes.WebJarAssets.at(p).url)
+        }
+      }
+  }
+
   private lazy val webJarAssetLocator = new WebJarAssetLocator(
     WebJarAssetLocator.getFullPathIndex(
       new Regex(webJarFilterExpr).pattern, environment.classLoader
     )
   )
 
+  private[this] def removePrefix(s: String): String =
+    s.stripPrefix(WebJarAssetLocator.WEBJARS_PATH_PREFIX + "/")
+
   /**
     * Locate a file in a WebJar
     *
-    * @example Passing in `jquery.min.js` will return `jquery/1.8.2/jquery.min.js` assuming the jquery WebJar version 1.8.2 is on the classpath
+    * @example Passing in `jquery.min.js` will return a WebJarAsset,
+    *          assuming the jquery WebJar version 1.8.2 is on the classpath
     *
     * @param file the file or partial path to find
-    * @return the path to the file (sans-the webjars prefix)
+    * @return the located WebJarAsset
     *
     */
-  def locate(file: String): Try[String] = {
-    Try(webJarAssetLocator.getFullPath(file).stripPrefix(WebJarAssetLocator.WEBJARS_PATH_PREFIX + "/"))
+  def locate(file: String): WebJarAsset = {
+    new WebJarAsset(Try(
+      removePrefix(webJarAssetLocator.getFullPath(file))))
   }
 
   /**
@@ -53,295 +126,27 @@ class WebJarsUtil @Inject() (configuration: Configuration, environment: Environm
     *
     * @param webJar the WebJar artifactId
     * @param path the file or partial path to find
-    * @return the path to the file (sans-the webjars prefix)
+    * @return the located WebJarAsset
     *
     */
-  def locate(webJar: String, path: String): Try[String] = {
-    Try(webJarAssetLocator.getFullPath(webJar, path).stripPrefix(WebJarAssetLocator.WEBJARS_PATH_PREFIX + "/"))
+  def locate(webJar: String, path: String): WebJarAsset = {
+    new WebJarAsset(Try(
+      removePrefix(webJarAssetLocator.getFullPath(webJar, path))))
   }
 
   /**
     * Get the full path to a file in a WebJar without validating that the file actually exists
     *
-    * @example Calling fullPath("react", "react.js") will return the full path to the file in the WebJar because react.js exists at the root of the WebJar
+    * @example Calling fullPath("react", "react.js") will return
+    *          a WebJarAsset because react.js exists at the root of the WebJar
     *
     * @param webjar the WebJar artifactId
     * @param path the full path to a file in the WebJar
-    * @return the path to the file (sans-the webjars prefix)
+    * @return the located WebJarAsset
     *
     */
-  def fullPath(webjar: String, path: String): Try[String] = {
-    val versionTry = Try(webJarAssetLocator.getWebJars.get(webjar))
-    versionTry.map { version =>
-      s"$webjar/$version/$path"
-    }
-  }
-
-  /**
-    * Get the groupId from a path
-    *
-    * @example groupId("jquery/1.9.0/jquery.js") will return "org.webjars" if the classpath contains the org.webjars jquery jar
-    *
-    * @param path a string to parse a WebJar name from
-    * @return the artifact groupId based on the classpath
-    */
-  def groupId(path: String): Try[String] = {
-    val webJar = path.split("/").head
-    val suffix = s"/$webJar/pom.xml"
-    val prefix = "META-INF/maven/"
-    val fullPathTry = Try(webJarAssetLocator.getFullPath(suffix))
-
-    fullPathTry.map(_.stripSuffix(suffix).stripPrefix(prefix))
-  }
-
-  /**
-    * Based on config, either returns a local url or a cdn url for a given asset path
-    *
-    * @param pathTry Possibly a path to convert to a local url or cdn url
-    * @return Possibly the local or cdn url
-    */
-  def localOrCdnUrl(pathTry: Try[String]): Try[String] = {
-    pathTry.flatMap { path =>
-      if (useCdn) {
-        val groupIdTry = groupId(path)
-        groupIdTry.map { groupId =>
-          s"$cdnUrl/$groupId/$path"
-        }
-      }
-      else {
-        Success(routes.WebJarAssets.at(path).url)
-      }
-    }
-  }
-
-
-  /**
-    * Locates a WebJar from a partial path and returns the reverse route or CDN URL
-    *
-    * @param path The partial path of a file in a WebJar
-    * @return The reverse route to the WebJar asset
-    */
-  def url(path: String): Try[String] = {
-    localOrCdnUrl(locate(path))
-  }
-
-  /**
-    * Locates a WebJar from a partial path and returns the reverse route
-    *
-    * @param webJar The artifact name of the WebJar
-    * @param path The partial path of a file in a WebJar
-    * @return The reverse route to the WebJar asset
-    */
-  def url(webJar: String, path: String): Try[String] = {
-    localOrCdnUrl(locate(webJar, path))
-  }
-
-  /**
-    * Turns a possible url into a tag using a provided function.  Uses the mode of the application to determine if an error should be returned or not.
-    *
-    * @param urlTry A possible url
-    * @param f A function that will render a successful url
-    * @return The tag to be rendered or when there is an error, an emtpy string in Prod mode and an error comment otherwise
-    */
-  def tag(urlTry: Try[String])(f: String => String): String = {
-    urlTry match {
-      case Success(url) =>
-        f(url)
-      case Failure(e) =>
-        Logger.error("Could not get URL", e)
-        environment.mode match {
-          case Mode.Prod =>
-            ""
-          case _ =>
-            s"""<!-- Could not get URL: ${e.getMessage} -->"""
-        }
-    }
-  }
-
-  /**
-    * Turns a path into a tag using a provided function.  Uses the mode of the application to determine if an error should be returned or not.
-    *
-    * @param path The partial path of a file in a WebJar
-    * @param f A function that will render a successful url
-    * @return The tag to be rendered or when there is an error, an emtpy string in Prod mode and an error comment otherwise
-    *
-    */
-  def tag(path: String)(f: String => String): String = {
-    tag(url(path))(f)
-  }
-
-  /**
-    * A script tag
-    *
-    * @param urlTry A possible url
-    * @param otherParams Other params for the script tag
-    * @return A string with the tag or an error / empty string (depending on mode)
-    */
-  def script(urlTry: Try[String], otherParams: Map[String, String] = Map.empty[String, String]): String = {
-    tag(urlTry) { url =>
-      val params = otherParams.map { case (name, value) =>
-        s"""$name="$value""""
-      }.mkString(" ")
-
-      s"""<script src="$url" $params></script>"""
-    }
-  }
-
-  /**
-    * A script tag
-    *
-    * @param call A call that becomes a url
-    * @return A string with the tag or an error / empty string (depending on mode)
-    */
-  def script(call: Call): String = {
-    script(Success(call.url))
-  }
-
-  /**
-    * A script tag
-    *
-    * @param path A path that becomes a url
-    * @return A string with the tag or an error / empty string (depending on mode)
-    */
-  def script(path: String): String = {
-    script(url(path))
-  }
-
-  /**
-    * A script tag
-    *
-    * @param webJar Name of the WebJar
-    * @param path A path to an asset in the WebJar
-    * @return A string with the tag or an error / empty string (depending on mode)
-    */
-  def script(webJar: String, path: String): String = {
-    script(url(webJar, path))
-  }
-
-  /**
-    * A script tag
-    *
-    * @param webJar Name of the WebJar
-    * @param path A path to an asset in the WebJar
-    * @param otherParams Other params to add to the script tag
-    * @return A string with the tag or an error / empty string (depending on mode)
-    */
-  def scriptWithParams(webJar: String, path: String, otherParams: Map[String, String]): String = {
-    script(url(webJar, path), otherParams)
-  }
-
-  /**
-    * A CSS link tag
-    *
-    * @param urlTry A possible url
-    * @return A string with the tag or an error / empty string (depending on mode)
-    */
-  def css(urlTry: Try[String]): String = {
-    tag(urlTry) { url =>
-      s"""<link rel="stylesheet" type="text/css" href="$url">"""
-    }
-  }
-
-  /**
-    * A CSS link tag
-    *
-    * @param call A call that will become a url
-    * @return A string with the tag or an error / empty string (depending on mode)
-    */
-  def css(call: Call): String = {
-    css(Success(call.url))
-  }
-
-  /**
-    * A CSS link tag
-    *
-    * @param path A call that will become a url
-    * @return A string with the tag or an error / empty string (depending on mode)
-    */
-  def css(path: String): String = {
-    css(url(path))
-  }
-
-  /**
-    * A CSS link tag
-    *
-    * @param webJar Name of the WebJar
-    * @param path A path to an asset in the WebJar
-    * @return A string with the tag or an error / empty string (depending on mode)
-    */
-  def css(webJar: String, path: String): String = {
-    css(url(webJar, path))
-  }
-
-  /**
-    * A img tag
-    *
-    * @param urlTry A possible url
-    * @param otherParams Other params for the script tag
-    * @return A string with the tag or an error / empty string (depending on mode)
-    */
-  def img(urlTry: Try[String], otherParams: Map[String, String] = Map.empty[String, String]): String = {
-    tag(urlTry) { url =>
-      val params = otherParams.map { case (name, value) =>
-        s"""$name="$value""""
-      }.mkString(" ")
-
-      s"""<img src="$url" $params>"""
-    }
-  }
-
-  /**
-    * A img tag
-    *
-    * @param call A call that becomes a url
-    * @return A string with the tag or an error / empty string (depending on mode)
-    */
-  def img(call: Call): String = {
-    img(Success(call.url))
-  }
-
-  /**
-    * A img tag
-    *
-    * @param path A path that becomes a url
-    * @return A string with the tag or an error / empty string (depending on mode)
-    */
-  def img(path: String): String = {
-    img(url(path))
-  }
-
-  /**
-    * A script tag
-    *
-    * @param webJar Name of the WebJar
-    * @param path A path to an asset in the WebJar
-    * @return A string with the tag or an error / empty string (depending on mode)
-    */
-  def img(webJar: String, path: String): String = {
-    img(url(webJar, path))
-  }
-
-  /**
-    * A img tag
-    *
-    * @param path A path to an asset in the WebJar
-    * @param otherParams Other params to add to the script tag
-    * @return A string with the tag or an error / empty string (depending on mode)
-    */
-  def imgWithParams(path: String, otherParams: Map[String, String]): String = {
-    img(url(path), otherParams)
-  }
-
-  /**
-    * A img tag
-    *
-    * @param webJar Name of the WebJar
-    * @param path A path to an asset in the WebJar
-    * @param otherParams Other params to add to the script tag
-    * @return A string with the tag or an error / empty string (depending on mode)
-    */
-  def imgWithParams(webJar: String, path: String, otherParams: Map[String, String]): String = {
-    img(url(webJar, path), otherParams)
+  def fullPath(webjar: String, path: String): WebJarAsset = {
+    new WebJarAsset(Try(removePrefix(webJarAssetLocator.getFullPathExact(webjar, path))))
   }
 
   /**
@@ -350,12 +155,12 @@ class WebJarsUtil @Inject() (configuration: Configuration, environment: Environm
     * @param mainUrl The reverse route of the main app
     * @return The RequireJS config and main script tags
     */
-  def requireJs(mainUrl: Call): String = {
-    val setup = script(routes.RequireJS.setup())
+  def requireJs(mainUrl: Call): Html = {
+    val setup: Html = html.script(routes.RequireJS.setup().url)
 
-    val main = scriptWithParams("requirejs", "require.min.js", Map("data-main" -> mainUrl.url))
+    val main: Html = fullPath("requirejs", "require.min.js").script(Map("data-main" -> mainUrl.url))
 
-    setup + main
+    HtmlFormat.fill(List(setup, main))
   }
 
 }

--- a/src/main/twirl/org/webjars/play/css.scala.html
+++ b/src/main/twirl/org/webjars/play/css.scala.html
@@ -1,0 +1,2 @@
+@(url: String, params: Map[String, String] = Map.empty)
+<link rel="stylesheet" type="text/css" href="@url" @for(p <- params) { @{p._1}="@{p._2}" }>

--- a/src/main/twirl/org/webjars/play/img.scala.html
+++ b/src/main/twirl/org/webjars/play/img.scala.html
@@ -1,0 +1,2 @@
+@(url: String, params: Map[String, String] = Map.empty)
+<img src="@url" @for(p <- params) { @{p._1}="@{p._2}" }>

--- a/src/main/twirl/org/webjars/play/script.scala.html
+++ b/src/main/twirl/org/webjars/play/script.scala.html
@@ -1,0 +1,2 @@
+@(url: String, params: Map[String, String] = Map.empty)
+<script src="@url" @for(p <- params) { @{p._1}="@{p._2}" }></script>

--- a/src/test/scala/org/webjars/play/WebJarsUtilSpec.scala
+++ b/src/test/scala/org/webjars/play/WebJarsUtilSpec.scala
@@ -5,8 +5,10 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.{Configuration, Environment, Mode}
 import play.api.mvc.Call
 import play.api.test.{FakeRequest, PlaySpecification, WithApplication}
+import play.twirl.api.Html
 
 import scala.collection.JavaConverters._
+import scala.util.Try
 
 class WebJarsUtilSpec extends PlaySpecification {
 
@@ -29,115 +31,115 @@ class WebJarsUtilSpec extends PlaySpecification {
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
 
       val requireJsPath = webJarsUtil.locate("require.js")
-      requireJsPath must beASuccessfulTry("requirejs/2.3.3/require.js")
+      requireJsPath.path must beASuccessfulTry("requirejs/2.3.3/require.js")
     }
     "be able to locate an asset with a webjar specified" in new WithApplication {
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
 
       val bootstrapPath = webJarsUtil.locate("bootswatch-yeti", "bootstrap.min.css")
-      bootstrapPath must beASuccessfulTry("bootswatch-yeti/3.1.1/css/bootstrap.min.css")
+      bootstrapPath.path must beASuccessfulTry("bootswatch-yeti/3.1.1/css/bootstrap.min.css")
     }
     "get a MultipleMatchesException if there are multiple matches" in new WithApplication {
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
 
-      webJarsUtil.locate("react.js") must beAFailedTry
-      webJarsUtil.locate("react", "react.js") must beAFailedTry
+      webJarsUtil.locate("react.js").path must beAFailedTry
+      webJarsUtil.locate("react", "react.js").path must beAFailedTry
     }
     "be able to locate an asset which normally has multiple matches" in new WithApplication {
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
-      webJarsUtil.fullPath("react", "react.js") must beASuccessfulTry("react/0.12.2/react.js")
+      webJarsUtil.fullPath("react", "react.js").path must beASuccessfulTry("react/0.12.2/react.js")
     }
     "url" in new WithApplication {
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
-      webJarsUtil.url("requirejs/2.3.3/require.js") must beASuccessfulTry("/webjars/requirejs/2.3.3/require.js")
-      webJarsUtil.url("requirejs", "requirejs/2.3.3/require.js") must beASuccessfulTry("/webjars/requirejs/2.3.3/require.js")
-      webJarsUtil.url("asdf1234qwer4321") must beAFailedTry
+      webJarsUtil.locate("requirejs/2.3.3/require.js").url must beASuccessfulTry("/webjars/requirejs/2.3.3/require.js")
+      webJarsUtil.locate("requirejs", "requirejs/2.3.3/require.js").url must beASuccessfulTry("/webjars/requirejs/2.3.3/require.js")
+      webJarsUtil.locate("asdf1234qwer4321").url must beAFailedTry
     }
     "url with a cdn" in new WithApplication(_.configure("webjars.use-cdn" -> "true")) {
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
-      webJarsUtil.url("require.js") must beASuccessfulTry("https://cdn.jsdelivr.net/webjars/org.webjars/requirejs/2.3.3/require.js")
+      webJarsUtil.locate("require.js").url must beASuccessfulTry("https://cdn.jsdelivr.net/webjars/org.webjars/requirejs/2.3.3/require.js")
     }
     "url with a custom cdn" in new WithApplication(_.configure("webjars.use-cdn" -> "true", "webjars.cdn-url" -> "http://asdf.com")) {
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
-      webJarsUtil.url("require.js") must beASuccessfulTry("http://asdf.com/org.webjars/requirejs/2.3.3/require.js")
+      webJarsUtil.locate("require.js").url must beASuccessfulTry("http://asdf.com/org.webjars/requirejs/2.3.3/require.js")
     }
     "generate a script tag from a partial WebJar path" in new WithApplication {
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
-      val script = webJarsUtil.script("jquery.js")
-      script must beEqualTo("""<script src="/webjars/jquery/1.9.0/jquery.js" ></script>""")
+      val script = webJarsUtil.locate("jquery.js").script()
+      script.body.trim must beEqualTo("""<script src="/webjars/jquery/1.9.0/jquery.js" ></script>""")
     }
     "generate an error comment when the path isn't found" in new WithApplication {
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
-      val script = webJarsUtil.script("asdf1234")
-      script must beEqualTo("""<!-- Could not get URL: asdf1234 could not be found. Make sure you've added the corresponding WebJar and please check for typos. -->""")
+      val script = Try(webJarsUtil.locate("asdf1234").script())
+      script must beAFailedTry
     }
     "generate an empty string when the path isn't found in prod mode" in new WithProdApplication {
       app.environment.mode must beEqualTo(Mode.Prod)
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
-      val script = webJarsUtil.script("asdf1234")
-      script must beEqualTo("")
+      val script = webJarsUtil.locate("asdf1234").script()
+      script.body must beEqualTo("")
     }
     "generate a script tag with a cdn url from a partial WebJar path" in new WithApplication(_.configure("webjars.use-cdn" -> "true")) {
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
-      val script = webJarsUtil.script("jquery.js")
-      script must beEqualTo("""<script src="https://cdn.jsdelivr.net/webjars/org.webjars/jquery/1.9.0/jquery.js" ></script>""")
+      val script = webJarsUtil.locate("jquery.js").script()
+      script.body.trim must beEqualTo("""<script src="https://cdn.jsdelivr.net/webjars/org.webjars/jquery/1.9.0/jquery.js" ></script>""")
     }
     "generate a css tag from a partial WebJar path" in new WithApplication {
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
-      val css = webJarsUtil.css("bootswatch-yeti", "bootstrap.css")
-      css must beEqualTo("""<link rel="stylesheet" type="text/css" href="/webjars/bootswatch-yeti/3.1.1/css/bootstrap.css">""")
+      val css = webJarsUtil.locate("bootswatch-yeti", "bootstrap.css").css()
+      css.body.trim must beEqualTo("""<link rel="stylesheet" type="text/css" href="/webjars/bootswatch-yeti/3.1.1/css/bootstrap.css" >""")
     }
     "generate an error comment when the path isn't found" in new WithApplication {
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
-      val css = webJarsUtil.css("asdf1234")
-      css must beEqualTo("""<!-- Could not get URL: asdf1234 could not be found. Make sure you've added the corresponding WebJar and please check for typos. -->""")
+      val css = Try(webJarsUtil.locate("asdf1234").css())
+      css must beAFailedTry
     }
     "generate an empty string when the path isn't found in prod mode" in new WithProdApplication {
       app.environment.mode must beEqualTo(Mode.Prod)
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
-      val css = webJarsUtil.css("asdf1234")
-      css must beEqualTo("")
+      val css = webJarsUtil.locate("asdf1234").css()
+      css.body must beEqualTo("")
     }
     "generate a css tag with a cdn url from a partial WebJar path" in new WithApplication(_.configure("webjars.use-cdn" -> "true")) {
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
-      val css = webJarsUtil.css("bootswatch-yeti", "bootstrap.css")
-      css must beEqualTo("""<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/webjars/org.webjars/bootswatch-yeti/3.1.1/css/bootstrap.css">""")
+      val css = webJarsUtil.locate("bootswatch-yeti", "bootstrap.css").css()
+      css.body.trim must beEqualTo("""<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/webjars/org.webjars/bootswatch-yeti/3.1.1/css/bootstrap.css" >""")
     }
     "generate an img tag from a partial WebJar path" in new WithApplication {
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
-      val img = webJarsUtil.img("bootswatch-yeti", "bootstrap.css")
-      img must beEqualTo("""<img src="/webjars/bootswatch-yeti/3.1.1/css/bootstrap.css" >""")
+      val img = webJarsUtil.locate("bootswatch-yeti", "bootstrap.css").img()
+      img.body.trim must beEqualTo("""<img src="/webjars/bootswatch-yeti/3.1.1/css/bootstrap.css" >""")
     }
     "generate an error comment when the path isn't found" in new WithApplication {
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
-      val img = webJarsUtil.img("asdf1234")
-      img must beEqualTo("""<!-- Could not get URL: asdf1234 could not be found. Make sure you've added the corresponding WebJar and please check for typos. -->""")
+      val img = Try(webJarsUtil.locate("asdf1234").img())
+      img must beAFailedTry
     }
     "generate an empty string when the path isn't found in prod mode" in new WithProdApplication {
       app.environment.mode must beEqualTo(Mode.Prod)
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
-      val img = webJarsUtil.img("asdf1234")
-      img must beEqualTo("")
+      val img = webJarsUtil.locate("asdf1234").img()
+      img.body must beEqualTo("")
     }
     "generate a css tag with a cdn url from a partial WebJar path" in new WithApplication(_.configure("webjars.use-cdn" -> "true")) {
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
-      val img = webJarsUtil.img("bootswatch-yeti", "bootstrap.css")
-      img must beEqualTo("""<img src="https://cdn.jsdelivr.net/webjars/org.webjars/bootswatch-yeti/3.1.1/css/bootstrap.css" >""")
+      val img = webJarsUtil.locate("bootswatch-yeti", "bootstrap.css").img()
+      img.body.trim must beEqualTo("""<img src="https://cdn.jsdelivr.net/webjars/org.webjars/bootswatch-yeti/3.1.1/css/bootstrap.css" >""")
     }
     "generate a requireJs config" in new WithApplication {
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
       val requireJs = webJarsUtil.requireJs(Call("GET", "/assets/js/app"))
 
-      requireJs must contain("""<script src="/webjars/_requirejs" ></script>""")
-      requireJs must contain("""<script src="/webjars/requirejs/2.3.3/require.min.js" data-main="/assets/js/app"></script>""")
+      requireJs.body must contain ("""<script src="/webjars/_requirejs" ></script>""")
+      requireJs.body must contain("""<script src="/webjars/requirejs/2.3.3/require.min.js"  data-main="/assets/js/app" ></script>""")
     }
     "generate a requireJs config with a cdn" in new WithApplication(_.configure("webjars.use-cdn" -> "true")) {
       val webJarsUtil = app.injector.instanceOf[WebJarsUtil]
 
       val requireJs = webJarsUtil.requireJs(Call("GET", "/assets/js/app"))
 
-      requireJs must contain("""<script src="/webjars/_requirejs" ></script>""")
-      requireJs must contain("""<script src="https://cdn.jsdelivr.net/webjars/org.webjars/requirejs/2.3.3/require.min.js" data-main="/assets/js/app"></script>""")
+      requireJs.body must contain("""<script src="/webjars/_requirejs" ></script>""")
+      requireJs.body must contain("""<script src="https://cdn.jsdelivr.net/webjars/org.webjars/requirejs/2.3.3/require.min.js"  data-main="/assets/js/app" ></script>""")
     }
   }
 

--- a/test-project/app/views/index.scala.html
+++ b/test-project/app/views/index.scala.html
@@ -3,10 +3,10 @@
 <!DOCTYPE html>
 <html>
     <head>
-        @Html(webJarUtil.css("bootstrap.min.css"))
+        @webJarUtil.locate("bootstrap.min.css").css()
         <link rel='stylesheet' href='@routes.Assets.versioned("stylesheets/index.css")'>
 
-        @Html(webJarUtil.requireJs(routes.Assets.versioned("javascripts/index.js")))
+        @webJarUtil.requireJs(routes.Assets.versioned("javascripts/index.js"))
     </head>
     <body>
         <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">


### PR DESCRIPTION
Hey @jamesward,

as discussed in #79, I have rewritten WebJarsUtil. It is now significantly shorter and more flexible as it doesn't conflate how to locate an asset with what to do with it once it's found.
Rather than `@Html(webJarUtils.script(webJarUtils.localOrCdnUrl(webJarUtils.fullPath("bar", "qux.js"))))` you can now write `@webJarUtils.fullPath("bar", "qux.js").script()`. Note that not only is this much easier but also that the `@Html(…)` stuff goes away.

Some things are a little longer now, for instance what used to be `@Html(webJarsUtil.script("foo", "bar.js")` is now `@webJarsUtil.locate("foo", "bar.js").script()` (4 characters longer), but I think the added flexibility is worth it. To make things even more terse, we could rename one of `WebJarsUtil`'s methods to `apply`. I would suggest `fullPath` as I think it's probably the most robust way to locate a Webjar asset, it doesn't break as easily as `locate` when you e. g. upgrade a library.

If additional attributes are specified, they are now escaped correctly, making the library safer to use.

If a webjar is not found in dev/test mode, the library will now just blow up rather than generate a comment, making errors harder to miss.

Take a look and let me know what you think.