### PR TITLE
upgraded to Play 2.7.0-RC9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ sources in (Compile, play.sbt.routes.RoutesKeys.routes) ++= ((unmanagedResourceD
 
 sources in (Test, play.sbt.routes.RoutesKeys.routes) ++= ((unmanagedResourceDirectories in Test).value * "routes").get
 
-val playVersion = "2.7.0-RC3"
+val playVersion = "2.7.0-RC9"
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play" % playVersion % "provided",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0-M2")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.0-RC3")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.0-RC9")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 


### PR DESCRIPTION
New status code were added to Play 2.7.0, see https://github.com/playframework/playframework/pull/8903

webjars-play needs a new release otherwise we get 

```
Error injecting constructor, java.lang.AbstractMethodError: 
Method org/webjars/play/RequireJS.play$api$mvc$Results$_setter_$PreconditionRequired_$eq(Lplay/api/mvc/Results$Status;)V is abstract
```
See https://travis-ci.org/playframework/play-scala-chatroom-example/jobs/478091705#L982