### PR TITLE
bumped webjar-locator version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ resolvers += Resolver.mavenLocal
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play" % playVersion % "provided",
   "org.webjars" % "requirejs" % "2.3.6",
-  "org.webjars" % "webjars-locator" % "0.38",
+  "org.webjars" % "webjars-locator" % "0.40",
   "com.typesafe.play" %% "play-test" % playVersion % "test",
   "com.typesafe.play" %% "play-specs2" % playVersion % "test",
   "org.webjars" % "bootstrap" % "3.1.0" % "test",


### PR DESCRIPTION
Hi!
I ran into a minor issue after upgrading an application to use Play 2.8.
After the upgrade I started to see a lot of log messages from the `ClassGraph` library on my console and started to investigate.
I was able to reproduce the issue using this example project:
https://github.com/landlockedsurfer/webjars-play28-example
I also got help from @lukehutch in the `ClassGraph` issue tracker:
https://github.com/classgraph/classgraph/issues/438