### PR TITLE
Updates the Play version to 3.0.10

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.9")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.10")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")


### PR DESCRIPTION
This allows applications using this libary to safely update to Play 3.0.10, to resolve the lz4 vulnerabilities.

There are some other versions that might want bumping, but since the 3.0.10 Pay release has been driven by a security vulnerbaility it might make sense to make a minimal change here.